### PR TITLE
Fix onnx export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+*.onnx
+*.pt

--- a/export_onnx.py
+++ b/export_onnx.py
@@ -76,7 +76,8 @@ def main():
         input_names=['feats'],
         output_names=['prob'],
         dynamic_axes={
-            'feats': {0: 'batch_size', 2: 'time_dim'}
+            'feats': {0: 'batch_size', 2: 'time_dim'},
+            'prob': {0: 'batch_size'}
         }
     )
 

--- a/onnx_inference_with_kaldi.py
+++ b/onnx_inference_with_kaldi.py
@@ -54,7 +54,6 @@ def main():
     features = torch.stack(features)
     mel = features.unsqueeze(0).permute(0,2,1)
 
-
     providers = ['CPUExecutionProvider']
     sess_options = ort.SessionOptions()
     sess = ort.InferenceSession(
@@ -62,8 +61,11 @@ def main():
 
     mellen = mel.shape[2]
     start = 0
-    while start + 1000 <= mellen: #10-second detection once
+    while True:
+        #10-second detection once
         melt = mel[:,:,start:start + 1000]
+        if melt.shape[-1] == 0:
+            break
         start += 1000
 
         x = sess.run(None, input_feed={'feats': melt.numpy()})


### PR DESCRIPTION
The output batch size dimension should also be dynamic in onnx export.

Also, when the input wave is less than 10 seconds in `onnx_inference_with_kaldi.py`, we should handle it correctly.