### PR TITLE
Support specifying max number of frames the model can process.

### DIFF
--- a/export_onnx.py
+++ b/export_onnx.py
@@ -55,10 +55,17 @@ def main():
         choices=models.list_models(),
         default='ced_mini')
 
+    parser.add_argument(
+        '--max-frames',
+        type=int,
+        default=1012,
+        help="Max number of frames the model can process."
+        )
+
     args = parser.parse_args()
 
 
-    model = getattr(models, args.model)(pretrained=True)
+    model = getattr(models, args.model)(target_length=args.max_frames, pretrained=True)
     model = model.to(DEVICE).eval()
 
     model = MyModel(model)


### PR DESCRIPTION
To fix the following error when the input wave is longer than 11 seconds.

```
2024-04-22 09:56:34.994 Python[2182:11259428] 2024-04-22 09:56:34.992914 [E:onnxruntime:, sequential_executor.cc:514 ExecuteKernel] Non-zero status code returned while running Add node. Name:'/Add' Status Message: /Users/runner/work/1/s/onnxruntime/core/providers/cpu/math/element_wise_ops.h:540 void onnxruntime::BroadcastIterator::Init(ptrdiff_t, ptrdiff_t) axis == 1 || axis == largest was false. Attempting to broadcast an axis by a dimension other than 1. 63 by 71
Traceback (most recent call last):
  File "./python-api-examples/audio-tagging-from-a-file-ced.py", line 119, in <module>
    main()
  File "./python-api-examples/audio-tagging-from-a-file-ced.py", line 94, in main
    result = audio_tagger.compute(stream)
RuntimeError: Non-zero status code returned while running Add node. Name:'/Add' Status Message: /Users/runner/work/1/s/onnxruntime/core/providers/cpu/math/element_wise_ops.h:540 void onnxruntime::BroadcastIterator::Init(ptrdiff_t, ptrdiff_t) axis == 1 || axis == largest was false. Attempting to broadcast an axis by a dimension other than 1. 63 by 71
```


---

By the way, please use `squash and merge`.

![Screenshot 2024-04-22 at 10 02 56](https://github.com/RicherMans/CED/assets/5284924/2cbf58ea-0e70-4713-84f5-e7aef138a315)
